### PR TITLE
Change how we set the setting for aurora.

### DIFF
--- a/lib/active_record/safer_migrations/postgresql_adapter.rb
+++ b/lib/active_record/safer_migrations/postgresql_adapter.rb
@@ -3,15 +3,10 @@
 module ActiveRecord
   module SaferMigrations
     module PostgreSQLAdapter
-      SET_SETTING_SQL = <<-SQL.
-      UPDATE
-        pg_settings
-      SET
-        setting = :value
-      WHERE
-        name = :setting_name
-      SQL
-        freeze
+      # aurora throws an error on updating pg_settings
+      # set_config(setting_name, new_value, is_local) is_local = false applies to the current session, else transaction
+      # https://www.postgresql.org/docs/11/functions-admin.html
+      SET_SETTING_SQL = "select set_config(:setting_name, :value::text, false)".freeze
 
       GET_SETTING_SQL = <<-SQL.
       SELECT


### PR DESCRIPTION
when trying to update `pg_settings` on amazon aurora we trigger:

```
aused by:
PG::ObjectNotInPrerequisiteState: ERROR:  cannot update view "pg_settings"
DETAIL:  Views that do not select from a single table or view are not automatically updatable.
HINT:  To enable updating the view, provide an INSTEAD OF UPDATE trigger or an unconditional ON UPDATE DO INSTEAD rule.
```

I haven't gotten to the bottom of _why_ this is the case yet, but we work around it by avoiding this. (tested on both aurora and regular pg.)